### PR TITLE
Ability to change Texture Format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub struct ImguiPlugin {
     pub font_oversample_v: i32,
     pub apply_display_scale_to_font_size: bool,
     pub apply_display_scale_to_font_oversample: bool,
-    pub texture_format: TextureFormat
+    pub texture_format: TextureFormat,
 }
 
 impl Default for ImguiPlugin {
@@ -124,7 +124,7 @@ impl Default for ImguiPlugin {
             font_oversample_v: 1,
             apply_display_scale_to_font_size: true,
             apply_display_scale_to_font_oversample: true,
-            texture_format: TextureFormat::Bgra8UnormSrgb
+            texture_format: TextureFormat::Bgra8UnormSrgb,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
     ptr::null_mut,
     sync::{Arc, Mutex},
 };
-use wgpu::{CommandEncoder, RenderPass, RenderPassDescriptor};
+use wgpu::{CommandEncoder, RenderPass, RenderPassDescriptor, TextureFormat};
 
 pub struct ImguiContext {
     ctx: Arc<Mutex<imgui::Context>>,
@@ -112,6 +112,7 @@ pub struct ImguiPlugin {
     pub font_oversample_v: i32,
     pub apply_display_scale_to_font_size: bool,
     pub apply_display_scale_to_font_oversample: bool,
+    pub texture_format: TextureFormat
 }
 
 impl Default for ImguiPlugin {
@@ -123,6 +124,7 @@ impl Default for ImguiPlugin {
             font_oversample_v: 1,
             apply_display_scale_to_font_size: true,
             apply_display_scale_to_font_oversample: true,
+            texture_format: TextureFormat::Bgra8UnormSrgb
         }
     }
 }
@@ -178,7 +180,7 @@ impl Plugin for ImguiPlugin {
                     device.wgpu_device(),
                     queue,
                     imgui_wgpu::RendererConfig {
-                        texture_format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                        texture_format: self.texture_format,
                         ..default()
                     },
                 );


### PR DESCRIPTION
Due to [https://github.com/bevyengine/bevy/blob/main/crates/bevy_render/src/view/window/mod.rs#L245](https://github.com/bevyengine/bevy/blob/main/crates/bevy_render/src/view/window/mod.rs#L245) the default TextureFormat might be different from Bgra8UnormSrgb